### PR TITLE
Remove need to be in a nerdpack for certain commands

### DIFF
--- a/src/extension-commands/list-subscriptions.ts
+++ b/src/extension-commands/list-subscriptions.ts
@@ -1,8 +1,10 @@
 import * as cliCommands from "./nr1-cli-commands";
-import runCommand from "../utils/run-command";
+import handleResponse from "../response-handlers/default";
+
+const cp = require("child_process");
 
 const listSubscriptions = () => {
-  runCommand(cliCommands.listSubscriptions());
+  cp.exec(cliCommands.listSubscriptions(), {}, handleResponse);
 };
 
 export default listSubscriptions;

--- a/src/extension-commands/select-default-profile.ts
+++ b/src/extension-commands/select-default-profile.ts
@@ -1,10 +1,10 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from "vscode";
-
-import * as cliCommands from "./nr1-cli-commands";
 import pickProfile from "../utils/pick-profile";
-import runCommand from "../utils/run-command";
+import * as cliCommands from "./nr1-cli-commands";
+
+const cp = require("child_process");
 
 const selectDefaultProfile = async () => {
   const profileName = await pickProfile();
@@ -15,8 +15,7 @@ const selectDefaultProfile = async () => {
         `Default profile updated to ${profileName}`
       );
     }
-
-    runCommand(cliCommands.setProfile(profileName), handleSetProfileResponse);
+    cp.exec(cliCommands.setProfile(profileName), {}, handleSetProfileResponse);
   }
 };
 


### PR DESCRIPTION
The `list subscriptions` and `select default profile` commands required to be in a nerdpack to run but they can be run outside of a nerdpack. This PR removes the need to be in a nerdpack to run the commands.